### PR TITLE
feat: Update theme context and provider

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,7 @@ module.exports = {
     ],
     '@typescript-eslint/no-unused-vars': 'warn',
     'no-debugger': 'warn',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    'no-constant-condition': 'warn',
   },
 };

--- a/src/context/theme/ThemeContext.hooks.ts
+++ b/src/context/theme/ThemeContext.hooks.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import ThemeContext from './ThemeContext';
+
+export function useThemeContext() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemeContext must be used within an ThemeProvider');
+  }
+  return context;
+}

--- a/src/context/theme/ThemeContext.ts
+++ b/src/context/theme/ThemeContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { ThemeContextType } from './ThemeContext.types';
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export default ThemeContext;

--- a/src/context/theme/ThemeContext.types.ts
+++ b/src/context/theme/ThemeContext.types.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export interface ThemeContextType {
+  toggleColorMode: () => void;
+}
+
+export interface ThemeProviderProps {
+  children: ReactNode;
+}

--- a/src/context/theme/ThemeProvider.tsx
+++ b/src/context/theme/ThemeProvider.tsx
@@ -1,0 +1,41 @@
+import { useMemo, useState } from 'react';
+import ThemeContext from './ThemeContext';
+import { ThemeContextType, ThemeProviderProps } from './ThemeContext.types';
+import { createTheme, ThemeProvider as MuiThemeProvider } from '@mui/material';
+import { useAuth } from '../auth';
+import { getDesignTokens } from './themes';
+
+export default function ThemeProvider({ children }: ThemeProviderProps) {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const { currentUser } = useAuth();
+
+  const theme = useMemo(
+    () =>
+      createTheme(
+        (currentUser as any)
+          .hasCustomTheme /* || true when we want to add a custom theme */
+          ? getDesignTokens(mode)
+          : {
+              palette: {
+                mode,
+              },
+            }
+      ),
+    [currentUser, mode]
+  );
+
+  const value: ThemeContextType = useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode((prevMode) => (prevMode === 'light' ? 'dark' : 'light'));
+      },
+    }),
+    []
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+}

--- a/src/context/theme/index.ts
+++ b/src/context/theme/index.ts
@@ -1,0 +1,3 @@
+export { default as ThemeProvider } from './ThemeProvider';
+export * from './ThemeContext.types';
+export * from './ThemeContext.hooks';

--- a/src/context/theme/themes.ts
+++ b/src/context/theme/themes.ts
@@ -1,0 +1,31 @@
+import { PaletteMode } from '@mui/material';
+import { amber, deepOrange, grey } from '@mui/material/colors';
+
+export const getDesignTokens = (mode: PaletteMode) => ({
+  palette: {
+    mode,
+    ...(mode === 'light'
+      ? {
+          // palette values for light mode
+          primary: amber,
+          divider: amber[200],
+          text: {
+            primary: grey[900],
+            secondary: grey[800],
+          },
+        }
+      : {
+          // palette values for dark mode
+          primary: deepOrange,
+          divider: deepOrange[700],
+          background: {
+            default: deepOrange[900],
+            paper: deepOrange[900],
+          },
+          text: {
+            primary: '#fff',
+            secondary: grey[500],
+          },
+        }),
+  },
+});

--- a/src/layouts/ClientLayout.tsx
+++ b/src/layouts/ClientLayout.tsx
@@ -5,6 +5,8 @@ import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import LogoutIcon from '@mui/icons-material/Logout';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { PrivateRoute } from 'src/components/common';
@@ -12,9 +14,14 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import APP_DRAWER, { DRAWER_WIDTH } from 'src/components/layouts/drawer';
 import { auth } from 'src/firebase';
 
-export default function ResponsiveDrawer() {
+import { ThemeProvider, useThemeContext } from 'src/context/theme';
+import { useTheme } from '@mui/material/styles';
+
+function ClientLayout() {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [isClosing, setIsClosing] = React.useState(false);
+  const theme = useTheme();
+  const themeContext = useThemeContext();
 
   const handleDrawerClose = () => {
     setIsClosing(true);
@@ -45,91 +52,110 @@ export default function ResponsiveDrawer() {
   }
 
   return (
-    <PrivateRoute>
-      <Box sx={{ display: 'flex' }}>
-        <AppBar
-          position="fixed"
+    <Box sx={{ display: 'flex' }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
+          ml: { sm: `${DRAWER_WIDTH}px` },
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            sx={{ mr: 2, display: { sm: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" flexGrow="1">
+            Champions
+          </Typography>
+          <IconButton
+            sx={{ ml: 1 }}
+            onClick={themeContext.toggleColorMode}
+            color="inherit"
+          >
+            {theme.palette.mode === 'dark' ? (
+              <Brightness4Icon />
+            ) : (
+              <Brightness7Icon />
+            )}
+          </IconButton>
+          <IconButton
+            color="inherit"
+            edge="end"
+            onClick={handleLogout}
+            sx={{ mr: 2 }}
+          >
+            <LogoutIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Box
+        component="nav"
+        sx={{ width: { sm: DRAWER_WIDTH }, flexShrink: { sm: 0 } }}
+        aria-label="mailbox folders"
+      >
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onTransitionEnd={handleDrawerTransitionEnd}
+          onClose={handleDrawerClose}
+          ModalProps={{
+            keepMounted: true,
+          }}
           sx={{
-            width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
-            ml: { sm: `${DRAWER_WIDTH}px` },
-            display: 'flex',
-            justifyContent: 'space-between',
+            display: { xs: 'block', sm: 'none' },
+            '& .MuiDrawer-paper': {
+              boxSizing: 'border-box',
+              width: DRAWER_WIDTH,
+            },
           }}
         >
-          <Toolbar>
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              edge="start"
-              onClick={handleDrawerToggle}
-              sx={{ mr: 2, display: { sm: 'none' } }}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography variant="h6" component="div" flexGrow="1">
-              Champions
-            </Typography>
-            <IconButton
-              color="inherit"
-              edge="end"
-              onClick={handleLogout}
-              sx={{ mr: 2 }}
-            >
-              <LogoutIcon />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-        <Box
-          component="nav"
-          sx={{ width: { sm: DRAWER_WIDTH }, flexShrink: { sm: 0 } }}
-          aria-label="mailbox folders"
-        >
-          <Drawer
-            variant="temporary"
-            open={mobileOpen}
-            onTransitionEnd={handleDrawerTransitionEnd}
-            onClose={handleDrawerClose}
-            ModalProps={{
-              keepMounted: true,
-            }}
-            sx={{
-              display: { xs: 'block', sm: 'none' },
-              '& .MuiDrawer-paper': {
-                boxSizing: 'border-box',
-                width: DRAWER_WIDTH,
-              },
-            }}
-          >
-            <APP_DRAWER />
-          </Drawer>
-          <Drawer
-            variant="permanent"
-            sx={{
-              display: { xs: 'none', sm: 'block' },
-              '& .MuiDrawer-paper': {
-                boxSizing: 'border-box',
-                width: DRAWER_WIDTH,
-              },
-            }}
-            open
-          >
-            <APP_DRAWER />
-          </Drawer>
-        </Box>
-        <Box
-          component="main"
+          <APP_DRAWER />
+        </Drawer>
+        <Drawer
+          variant="permanent"
           sx={{
-            flexGrow: 1,
-            p: 3,
-            width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
-            bgcolor: 'grey.50',
-            minHeight: '100vh',
+            display: { xs: 'none', sm: 'block' },
+            '& .MuiDrawer-paper': {
+              boxSizing: 'border-box',
+              width: DRAWER_WIDTH,
+            },
           }}
+          open
         >
-          <Toolbar />
-          <Outlet />
-        </Box>
+          <APP_DRAWER />
+        </Drawer>
       </Box>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: 3,
+          width: { sm: `calc(100% - ${DRAWER_WIDTH}px)` },
+          bgcolor: 'background.paper',
+          minHeight: '100vh',
+        }}
+      >
+        <Toolbar />
+        <Outlet />
+      </Box>
+    </Box>
+  );
+}
+
+export default function ClientLayoutWrapper() {
+  return (
+    <PrivateRoute>
+      <ThemeProvider>
+        <ClientLayout />
+      </ThemeProvider>
     </PrivateRoute>
   );
 }

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,1 @@
+export { default as ClientLayout } from './ClientLayout';


### PR DESCRIPTION
The code changes introduce updates to the theme context and provider. The `ThemeProvider` component now accepts a `children` prop and wraps the `MuiThemeProvider` component. The `ThemeContext` is exported from the `ThemeContext` module. Additionally, the `ThemeContext.types` and `ThemeContext.hooks` are exported from the `ThemeContext` module. These changes improve the organization and structure of the theme-related code.